### PR TITLE
feat: not working on Windows if there's a space in the script path

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ function fastFolderSize(target, cb) {
   // windows
   if (process.platform === 'win32') {
     return exec(
-      `${path.join('bin','du.exe')} -nobanner -accepteula ${target}`, (err, stdout) => {
+      `"${path.join(
+        __dirname,
+        'bin',
+        'du.exe'
+      )}" -nobanner -accepteula ${target}`,
+      (err, stdout) => {
         if (err) return cb(err)
 
         const match = /Size:\s+(.+) bytes/.exec(stdout)

--- a/index.js
+++ b/index.js
@@ -8,12 +8,7 @@ function fastFolderSize(target, cb) {
   // windows
   if (process.platform === 'win32') {
     return exec(
-      `${path.join(
-        __dirname,
-        'bin',
-        'du.exe'
-      )} -nobanner -accepteula ${target}`,
-      (err, stdout) => {
+      `${path.join('bin','du.exe')} -nobanner -accepteula ${target}`, (err, stdout) => {
         if (err) return cb(err)
 
         const match = /Size:\s+(.+) bytes/.exec(stdout)


### PR DESCRIPTION
Fixes #2 - Fixes not working on Windows if there's a space in the script path, by removing `__dirname`.