### PR TITLE
Fixes special characters and only downloads `du.exe` on Windows

### DIFF
--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -2,6 +2,9 @@ const https = require('https')
 const path = require('path')
 const unzipper = require('unzipper')
 
+// Only run for Windows
+if (process.platform !== 'win32') process.exit();
+
 https.get('https://download.sysinternals.com/files/DU.zip', function (res) {
   res.pipe(unzipper.Extract({ path: path.join(__dirname, 'bin') }))
 })

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function fastFolderSize(target, cb) {
         __dirname,
         'bin',
         'du.exe'
-      )}" -nobanner -accepteula ${target}`,
+      )}" -nobanner -accepteula .`, {cwd: target},
       (err, stdout) => {
         if (err) return cb(err)
 
@@ -26,7 +26,7 @@ function fastFolderSize(target, cb) {
 
   // mac
   if (process.platform === 'darwin') {
-    return exec(`du -sk ${target}`, (err, stdout) => {
+    return exec(`du -sk .`, {cwd: target}, (err, stdout) => {
       if (err) return cb(err)
 
       const match = /^(\d+)/.exec(stdout)
@@ -38,7 +38,7 @@ function fastFolderSize(target, cb) {
   }
 
   // others
-  return exec(`du -sb ${target}`, (err, stdout) => {
+  return exec(`du -sb .`, {cwd: target}, (err, stdout) => {
     if (err) return cb(err)
 
     const match = /^(\d+)/.exec(stdout)


### PR DESCRIPTION
Hi 👋🏻

I've forked your project and recoded parts of it in TypeScript for my own needs - Maybe you want to check out my improvements.

This PR contains 2 little fixes:
* Setting the working directory and calling `du` on `.` allows us to avoid escaping the path - Putting it inside `"` might help in most cases but if doesn't break on Windows, it does on Linux/ext as `"` is a valid character to use.
* Checking the OS before downloading `du.exe` onto a system that doesn't use it anyway