### PR TITLE
fix: special characters on localized Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function fastFolderSize(target, cb) {
         if (err) return cb(err)
 
         // query stats indexes from the end since path can contain commas as well
-        const stats = stdout.split("\n")[1].split(",")
+        const stats = stdout.split('\n')[1].split(',')
 
         cb(null, +stats.slice(-2)[0])
       }

--- a/index.js
+++ b/index.js
@@ -8,15 +8,15 @@ function fastFolderSize(target, cb) {
   // windows
   if (process.platform === 'win32') {
     return exec(
-      `"${path.join(__dirname, 'bin', 'du.exe')}" -nobanner -accepteula .`,
+      `"${path.join(__dirname, 'bin', 'du.exe')}" -nobanner -accepteula -q -c .`,
       { cwd: target },
       (err, stdout) => {
         if (err) return cb(err)
 
-        const match = /Size:\s+(.+) bytes/.exec(stdout)
-        const bytes = Number(match[1].replace(/\.|,/g, ''))
+        // query stats indexes from the end since path can contain commas as well
+        const stats = stdout.split("\n")[1].split(",")
 
-        cb(null, bytes)
+        cb(null, +stats.slice(-2)[0])
       }
     )
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-folder-size",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
For now, this module doesn't work on my windows machine (all tests are failing) because stdout look like that: `Size:         66�968�762 bytes`

This pr enables csv format which doesn't generate these weird characters at all.

Current du.exe usage (just in case):

```console
usage: du.exe [-c[t]] [-l <levels> | -n | -v] [-u] [-q] <directory>
   -c     Print output as CSV. Use -ct for tab delimiting.
          Use -nobanner to suppress banner.
   -l     Specify subdirectory depth of information (default is one level).
   -n     Do not recurse.
   -q     Quiet.
   -nobanner
          Do not display the startup banner and copyright message.
   -u     Count each instance of a hardlinked file.
   -v     Show size (in KB) of all subdirectories.

CSV output is formatted as:
Path,CurrentFileCount,CurrentFileSize,FileCount,DirectoryCount,DirectorySize,DirectorySizeOnDisk
```