### PR TITLE
Add sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm i fast-folder-size
 ```js
 const { promisify } = require('util')
 const fastFolderSize = require('fast-folder-size')
+const fastFolderSizeSync = require('fast-folder-size/sync')
 
 // callback
 fastFolderSize('.', (err, bytes) => {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ const fastFolderSizeAsync = promisify(fastFolderSize)
 const bytes = await fastFolderSizeAsync('.')
 
 console.log(bytes)
+
+// sync
+const bytes = fastFolderSizeSync('.')
+
+console.log(bytes)
 ```
 
 ### Command line

--- a/index.js
+++ b/index.js
@@ -6,18 +6,14 @@ const { commands, processOutput } = require('./os.js')
 function fastFolderSize(target, cb) {
   const command = commands[process.platform] || commands['linux']
 
-  return exec(
-    command,
-    { cwd: target },
-    (err, stdout) => {
-      if (err) return cb(err)
+  return exec(command, { cwd: target }, (err, stdout) => {
+    if (err) return cb(err)
 
-      const process = processOutput[process.platform] || processOutput['linux']
-      const bytes = process(stdout)
+    const processFn = processOutput[process.platform] || processOutput['linux']
+    const bytes = processFn(stdout)
 
-      cb(null, bytes)
-    }
-  )
+    cb(null, bytes)
+  })
 }
 
 module.exports = fastFolderSize

--- a/index.js
+++ b/index.js
@@ -1,52 +1,23 @@
 'use strict'
 
-const path = require('path')
 const { exec } = require('child_process')
+const { commands, processOutput } = require('./os.js')
 
 function fastFolderSize(target, cb) {
-  // windows
-  if (process.platform === 'win32') {
-    return exec(
-      `"${path.join(
-        __dirname,
-        'bin',
-        'du.exe'
-      )}" -nobanner -accepteula -q -c .`,
-      { cwd: target },
-      (err, stdout) => {
-        if (err) return cb(err)
+  const command = commands[process.platform] || commands['linux']
 
-        // query stats indexes from the end since path can contain commas as well
-        const stats = stdout.split('\n')[1].split(',')
-
-        cb(null, +stats.slice(-2)[0])
-      }
-    )
-  }
-
-  // mac
-  if (process.platform === 'darwin') {
-    return exec(`du -sk .`, { cwd: target }, (err, stdout) => {
+  return exec(
+    command,
+    { cwd: target },
+    (err, stdout) => {
       if (err) return cb(err)
 
-      const match = /^(\d+)/.exec(stdout)
-
-      const bytes = Number(match[1]) * 1024
+      const process = processOutput[process.platform] || processOutput['linux']
+      const bytes = process(stdout)
 
       cb(null, bytes)
-    })
-  }
-
-  // others
-  return exec(`du -sb .`, { cwd: target }, (err, stdout) => {
-    if (err) return cb(err)
-
-    const match = /^(\d+)/.exec(stdout)
-
-    const bytes = Number(match[1])
-
-    cb(null, bytes)
-  })
+    }
+  )
 }
 
 module.exports = fastFolderSize

--- a/os.js
+++ b/os.js
@@ -2,7 +2,11 @@ const path = require('path')
 
 const commands = {
   // windows
-  win32: `"${path.join(__dirname, 'bin', 'du.exe')}" -nobanner -accepteula -q -c .`,
+  win32: `"${path.join(
+    __dirname,
+    'bin',
+    'du.exe'
+  )}" -nobanner -accepteula -q -c .`,
 
   // macos
   darwin: `du -sk .`,

--- a/os.js
+++ b/os.js
@@ -1,0 +1,44 @@
+const path = require('path')
+
+const commands = {
+  // windows
+  win32: `"${path.join(__dirname, 'bin', 'du.exe')}" -nobanner -accepteula -q -c .`,
+
+  // macos
+  darwin: `du -sk .`,
+
+  // any linux
+  linux: `du -sb .`,
+}
+
+const processOutput = {
+  // windows
+  win32(stdout) {
+    // query stats indexes from the end since path can contain commas as well
+    const stats = stdout.split('\n')[1].split(',')
+
+    const bytes = +stats.slice(-2)[0]
+
+    return bytes
+  },
+
+  // macos
+  darwin(stdout) {
+    const match = /^(\d+)/.exec(stdout)
+
+    const bytes = Number(match[1]) * 1024
+
+    return bytes
+  },
+
+  // any linux
+  linux(stdout) {
+    const match = /^(\d+)/.exec(stdout)
+
+    const bytes = Number(match[1])
+
+    return bytes
+  },
+}
+
+module.exports = { commands, processOutput }

--- a/sync.js
+++ b/sync.js
@@ -1,43 +1,14 @@
 'use strict'
 
-const path = require('path')
 const { execSync } = require('child_process')
+const { commands, processOutput } = require('./os.js')
 
 function fastFolderSize(target) {
-  // windows
-  if (process.platform === 'win32') {
-    const stdout = execSync(
-      `"${path.join(
-        __dirname,
-        'bin',
-        'du.exe'
-      )}" -nobanner -accepteula -q -c .`,
-      { cwd: target }
-    )
+  const command = commands[process.platform] || commands['linux']
+  const stdout = execSync(command, { cwd: target })
 
-    // query stats indexes from the end since path can contain commas as well
-    const stats = stdout.split('\n')[1].split(',')
-
-    return +stats.slice(-2)[0]
-  }
-
-  // mac
-  if (process.platform === 'darwin') {
-    const stdout = execSync(`du -sk .`, { cwd: target })
-
-    const match = /^(\d+)/.exec(stdout)
-
-    const bytes = Number(match[1]) * 1024
-
-    return bytes
-  }
-
-  // others
-  const stdout = execSync(`du -sb .`, { cwd: target })
-
-  const match = /^(\d+)/.exec(stdout)
-
-  const bytes = Number(match[1])
+  const process = processOutput[process.platform] || processOutput['linux']
+  const bytes = process(stdout)
 
   return bytes
 }

--- a/sync.js
+++ b/sync.js
@@ -7,8 +7,8 @@ function fastFolderSize(target) {
   const command = commands[process.platform] || commands['linux']
   const stdout = execSync(command, { cwd: target })
 
-  const process = processOutput[process.platform] || processOutput['linux']
-  const bytes = process(stdout)
+  const processFn = processOutput[process.platform] || processOutput['linux']
+  const bytes = processFn(stdout)
 
   return bytes
 }

--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const path = require('path')
+const { execSync } = require('child_process')
+
+function fastFolderSize(target) {
+  // windows
+  if (process.platform === 'win32') {
+    const stdout = execSync(
+      `"${path.join(
+        __dirname,
+        'bin',
+        'du.exe'
+      )}" -nobanner -accepteula -q -c .`,
+      { cwd: target }
+    )
+
+    // query stats indexes from the end since path can contain commas as well
+    const stats = stdout.split('\n')[1].split(',')
+
+    return +stats.slice(-2)[0]
+  }
+
+  // mac
+  if (process.platform === 'darwin') {
+    const stdout = execSync(`du -sk .`, { cwd: target })
+
+    const match = /^(\d+)/.exec(stdout)
+
+    const bytes = Number(match[1]) * 1024
+
+    return bytes
+  }
+
+  // others
+  const stdout = execSync(`du -sb .`, { cwd: target })
+
+  const match = /^(\d+)/.exec(stdout)
+
+  const bytes = Number(match[1])
+
+  return bytes
+}
+
+module.exports = fastFolderSize

--- a/sync.js
+++ b/sync.js
@@ -5,7 +5,7 @@ const { commands, processOutput } = require('./os.js')
 
 function fastFolderSize(target) {
   const command = commands[process.platform] || commands['linux']
-  const stdout = execSync(command, { cwd: target })
+  const stdout = execSync(command, { cwd: target }).toString()
 
   const processFn = processOutput[process.platform] || processOutput['linux']
   const bytes = processFn(stdout)

--- a/test.js
+++ b/test.js
@@ -30,14 +30,10 @@ test('folder size is correct', t => {
 })
 
 test('sync: folder size is larger than 0', t => {
-  try {
-    const bytes = fastFolderSizeSync('.')
-    t.ok(Number.isFinite(bytes))
-    t.ok(bytes > 0)
-    t.end()
-  } catch (err) {
-    t.error(err)
-  }
+  const bytes = fastFolderSizeSync('.')
+  t.ok(Number.isFinite(bytes))
+  t.ok(bytes > 0)
+  t.end()
 })
 
 test('sync: folder size is correct', t => {
@@ -47,13 +43,9 @@ test('sync: folder size is correct', t => {
     whatever: crypto.randomBytes(writtenBytes),
   })
 
-  try {
-    const bytes = fastFolderSizeSync(testdirName)
-    console.log('real size:', writtenBytes, 'found size:', bytes)
-    t.ok(bytes >= writtenBytes)
-    t.ok(bytes <= writtenBytes * 1.5)
-    t.end()
-  } catch (err) {
-    t.error(err)
-  }
+  const bytes = fastFolderSizeSync(testdirName)
+  console.log('real size:', writtenBytes, 'found size:', bytes)
+  t.ok(bytes >= writtenBytes)
+  t.ok(bytes <= writtenBytes * 1.5)
+  t.end()
 })

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const { test } = require('tap')
 const crypto = require('crypto')
 
 const fastFolderSize = require('.')
+const fastFolderSizeSync = require('./sync')
 
 test('folder size is larger than 0', t => {
   fastFolderSize('.', (err, bytes) => {
@@ -26,4 +27,33 @@ test('folder size is correct', t => {
     t.ok(bytes <= writtenBytes * 1.5)
     t.end()
   })
+})
+
+test('sync: folder size is larger than 0', t => {
+  try {
+    const bytes = fastFolderSizeSync('.')
+    t.ok(Number.isFinite(bytes))
+    t.ok(bytes > 0)
+    t.end()
+  } catch (err) {
+    t.error(err)
+  }
+})
+
+test('sync: folder size is correct', t => {
+  const writtenBytes = 8 * 1024
+
+  const testdirName = t.testdir({
+    whatever: crypto.randomBytes(writtenBytes),
+  })
+
+  try {
+    const bytes = fastFolderSizeSync(testdirName)
+    console.log('real size:', writtenBytes, 'found size:', bytes)
+    t.ok(bytes >= writtenBytes)
+    t.ok(bytes <= writtenBytes * 1.5)
+    t.end()
+  } catch (err) {
+    t.error(err)
+  }
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,3 +6,8 @@ declare function fastFolderSize(
 ): ChildProcess
 
 export = fastFolderSize
+
+declare module 'fast-folder-size/sync' {
+  function fastFolderSize(path: string): number
+  export = fastFolderSize
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,6 @@ declare function fastFolderSize(
 export = fastFolderSize
 
 declare module 'fast-folder-size/sync' {
-  function fastFolderSize(path: string): number
-  export = fastFolderSize
+  function fastFolderSizeSync(path: string): number | undefined
+  export = fastFolderSizeSync
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import { ExecException, ChildProcess } from 'child_process'
+import fastFolderSizeSync from './sync'
 
 declare function fastFolderSize(
   path: string,
@@ -8,6 +9,5 @@ declare function fastFolderSize(
 export = fastFolderSize
 
 declare module 'fast-folder-size/sync' {
-  function fastFolderSizeSync(path: string): number | undefined
   export = fastFolderSizeSync
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd'
 import { ExecException, ChildProcess } from 'child_process'
 import fastFolderSize from '.'
+import fastFolderSizeSync from 'fast-folder-size/sync'
 
 expectType<ChildProcess>(
   fastFolderSize('.', (err, bytes) => {
@@ -8,3 +9,5 @@ expectType<ChildProcess>(
     expectType<number | undefined>(bytes)
   })
 )
+
+expectType<number | undefined>(fastFolderSizeSync('.'))

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import { expectType } from 'tsd'
 import { ExecException, ChildProcess } from 'child_process'
 import fastFolderSize from '.'
-import fastFolderSizeSync from 'fast-folder-size/sync'
+import fastFolderSizeSync from './sync'
 
 expectType<ChildProcess>(
   fastFolderSize('.', (err, bytes) => {

--- a/types/sync.d.ts
+++ b/types/sync.d.ts
@@ -1,0 +1,2 @@
+declare function fastFolderSizeSync(path: string): number | undefined
+export = fastFolderSizeSync


### PR DESCRIPTION
Sometimes, some packages use just the sync commands of node, no await.
It would be useful if this package offered a sync version as well.

With this PR, you would import it and use it like this:

```js
const fastFolderSizeSync = require('fast-folder-size/sync')

const bytes = fastFolderSizeSync('.')

console.log(bytes)
```