### PR TITLE
Fix yarn berry install with pnp

### DIFF
--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -4,7 +4,7 @@ const unzipper = require('unzipper')
 
 // Only run for Windows
 if (process.platform !== 'win32') {
-  process.exit()
+  process.exit(0)
 }
 
 https.get('https://download.sysinternals.com/files/DU.zip', function (res) {


### PR DESCRIPTION
When yarn berry is used, the postinstall script fails with the following error.

```sh
➤ YN0007: │ fast-folder-size@npm:1.6.1 must be built because it never has been before or the last one failed
➤ YN0009: │ fast-folder-size@npm:1.6.1 couldn't be built successfully (exit code 13, logs can be found here: /private/var/folders/4q/141y2kz96395wsmj82ljtxs00000gn/T/xfs-6293f042/build.log)
➤ YN0000: └ Completed in 1s 894ms
```

Forcing the exit code to be 0 fixes the issue