### PR TITLE
Feat: Option to specify DU.zip download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Node CLI or module to calculate folder size.
 
 It uses:
 
-- [Sysinternals DU](https://docs.microsoft.com/en-us/sysinternals/downloads/du) on Windows, automatically downloaded at installation time because the license does not allow redistribution
+- [Sysinternals DU](https://docs.microsoft.com/en-us/sysinternals/downloads/du) on Windows, automatically downloaded at installation time because the license does not allow redistribution. See below about specifying the download location.
 - native `du` on other platforms
 
 ## Installation
@@ -51,4 +51,15 @@ console.log(bytes)
 
 ```bash
 fast-folder-size .
+```
+
+### Downloading the Sysinternals DU.zip
+
+By default the Sysinternals DU.zip is downloaded from https://download.sysinternals.com/files/DU.zip.
+
+If you need to change this, e.g. to download from an internal package repository, 
+set the **FAST_FOLDER_SIZE_DU_ZIP_LOCATION** environment variable. For example:
+
+```shell
+export FAST_FOLDER_SIZE_DU_ZIP_LOCATION=https://your.internal.repository/DU.zip
 ```

--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -7,7 +7,7 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-const duZipLocation = process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION ?? 'https://download.sysinternals.com/files/DU.zip';
+const duZipLocation = process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION || 'https://download.sysinternals.com/files/DU.zip';
 
 https.get(duZipLocation, function (res) {
   res.pipe(unzipper.Extract({ path: path.join(__dirname, 'bin') }))

--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -7,6 +7,8 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-https.get('https://download.sysinternals.com/files/DU.zip', function (res) {
+const duZipLocation = process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION ?? 'https://download.sysinternals.com/files/DU.zip';
+
+https.get(duZipLocation, function (res) {
   res.pipe(unzipper.Extract({ path: path.join(__dirname, 'bin') }))
 })

--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -7,7 +7,7 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-const duZipLocation = process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION || 'https://download.sysinternals.com/files/DU.zip';
+const duZipLocation = process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION || 'https://download.sysinternals.com/files/DU.zip'
 
 https.get(duZipLocation, function (res) {
   res.pipe(unzipper.Extract({ path: path.join(__dirname, 'bin') }))

--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -7,7 +7,9 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-const duZipLocation = process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION || 'https://download.sysinternals.com/files/DU.zip'
+const duZipLocation =
+  process.env.FAST_FOLDER_SIZE_DU_ZIP_LOCATION ||
+  'https://download.sysinternals.com/files/DU.zip'
 
 https.get(duZipLocation, function (res) {
   res.pipe(unzipper.Extract({ path: path.join(__dirname, 'bin') }))


### PR DESCRIPTION
Add the ability to specify the download location of the DU.zip binary. 

This is useful for people working behind a corporate firewall where you can only download these things from internal repositories.

Resolves #18 