### PR TITLE
feat: actually add proxy support

### DIFF
--- a/get-sysinternals-du.js
+++ b/get-sysinternals-du.js
@@ -3,6 +3,7 @@ const os = require('os')
 const https = require('https')
 const path = require('path')
 const decompress = require('decompress')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 // Only run for Windows
 if (process.platform !== 'win32') {
@@ -30,15 +31,7 @@ const proxyAddress =
   process.env.http_proxy
 
 if (proxyAddress) {
-  const proxyOptions = new URL(proxyAddress)
-  const agent = new https.Agent({
-    proxy: {
-      host: proxyOptions.hostname,
-      port: proxyOptions.port || 8080,
-      protocol: proxyOptions.protocol,
-      auth: proxyOptions.auth,
-    },
-  })
+  const agent = new HttpsProxyAgent(proxyAddress)
 
   https.globalAgent = agent
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "AWISC",
       "dependencies": {
-        "decompress": "^4.2.1"
+        "decompress": "^4.2.1",
+        "https-proxy-agent": "^7.0.0"
       },
       "bin": {
         "fast-folder-size": "cli.js"
@@ -568,6 +569,17 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "dev": true,
@@ -1076,7 +1088,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2046,6 +2057,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2737,7 +2760,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "license": "AWISC",
   "dependencies": {
-    "decompress": "^4.2.1"
+    "decompress": "^4.2.1",
+    "https-proxy-agent": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.2.5",


### PR DESCRIPTION
Unfortunately the added proxy change in #25 does not seem to be working as `proxy` is not a valid option of `Agent`.
It would be possible to create a proxy Agent without external library, but I think using `https-proxy-agent` is the more robust solution.

